### PR TITLE
Hover on target: list sources

### DIFF
--- a/cmakels/src/cmake_query/cmake_query.cpp
+++ b/cmakels/src/cmake_query/cmake_query.cpp
@@ -98,8 +98,9 @@ cmMakefile *cmake_query::get_makefile(std::string const &uri) {
   return nullptr;
 }
 
-std::optional<location> cmake_query::get_target_info(std::string const &target,
-                                                     std::string const &uri) {
+std::optional<location>
+cmake_query::target_definition_location(std::string const &target,
+                                        std::string const &uri) {
   auto mf = get_makefile(uri);
   if (mf) {
     auto tgt = mf->FindTargetToUse(target);

--- a/cmakels/src/cmake_query/cmake_query.hpp
+++ b/cmakels/src/cmake_query/cmake_query.hpp
@@ -31,8 +31,8 @@ public:
   int configure() { return configure(root_dir_ / ".cmakels"); }
   int configure(fs::path const &cmake_query_build_dir);
   cmMakefile *get_makefile(std::string const &uri);
-  std::optional<location> get_target_info(std::string const &target,
-                                          std::string const &uri);
+  std::optional<location> target_definition_location(std::string const &target,
+                                                     std::string const &uri);
   std::optional<std::vector<std::string>>
   get_target_sources(std::string const &target, std::string const &uri);
   std::vector<std::string> get_target_names(std::string const &uri);

--- a/cmakels/src/core/cmake_language_server.cpp
+++ b/cmakels/src/core/cmake_language_server.cpp
@@ -81,16 +81,20 @@ cmake_language_server::hover(protocol::TextDocumentPositionParams position) {
         *(open_files_[position.textDocument.uri]),
         {static_cast<std::size_t>(position.position.line),
          static_cast<std::size_t>(position.position.character)});
-    auto ret = substitute_variables(parser::get_selected_token(result),
-                                    position.textDocument.uri, *query_);
-    if (auto target_location =
-            query_->get_target_info(ret, position.textDocument.uri)) {
+    auto selected_token = parser::get_selected_token(result);
+    auto ret = substitute_variables(selected_token, position.textDocument.uri,
+                                    *query_);
+    if (auto target_location = query_->target_definition_location(
+            ret, position.textDocument.uri)) {
       auto srcs = query_->get_target_sources(ret, position.textDocument.uri);
-      ret += " is a target!";
-      if (srcs)
+      std::string target_string = "Target *" + ret + "*";
+      if (srcs) {
+        target_string += "\n\nSources:";
         for (auto const &src : *srcs) {
-          ret += "\n" + src;
+          target_string += "\n\n" + src;
         }
+      }
+      return {target_string};
     }
     return {ret};
   } catch (std::runtime_error e) { // TODO fix this exception pattern
@@ -114,7 +118,7 @@ protocol::Location cmake_language_server::definition(
   }
   auto evaluated_selected_token = substitute_variables(
       parser::get_selected_token(result), position.textDocument.uri, *query_);
-  if (auto target_location = query_->get_target_info(
+  if (auto target_location = query_->target_definition_location(
           evaluated_selected_token, position.textDocument.uri)) {
     return {filename_to_uri(target_location->filename),
             {{static_cast<int>(target_location->line - 1), 0},

--- a/cmakels/test/test_cmake_query.cpp
+++ b/cmakels/test/test_cmake_query.cpp
@@ -30,7 +30,7 @@ TEST(cmake_query, configure) {
                                "/project1/.cmakels"));
 }
 
-TEST(cmake_query, get_target_info) {
+TEST(cmake_query, target_definition_location) {
   std::string root_dir =
       test_cmake_query_config::projects_src_dir + "/project1";
 
@@ -38,6 +38,6 @@ TEST(cmake_query, get_target_info) {
 
   query.configure(test_cmake_query_config::cmakefiles_dir +
                   "/project1/.cmakels");
-  ASSERT_TRUE(query.get_target_info(
+  ASSERT_TRUE(query.target_definition_location(
       "a_target", support::filename_to_uri(root_dir) + "/CMakeLists.txt"));
 }


### PR DESCRIPTION
Add `cmake_query::get_target_sources()` and add info to hover on targets.

Additional changes:
- rename `cmake_query::get_target_info()` -> `cmake_query::target_definition_location()` to free the name for a full target info.

<a href="https://gitpod.io/#https://github.com/havogt/cmakels/pull/59"><img src="https://gitpod.io/api/apps/github/pbs/github.com/havogt/cmakels.git/71d6476b5b71e8fe55eb43656e7aec9fdf0aa669.svg" /></a>

