### PR TITLE
Allow replying with notification to notification

### DIFF
--- a/lscpp/examples/experimental_sample_server/sample_server.cpp
+++ b/lscpp/examples/experimental_sample_server/sample_server.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <lscpp/experimental/messages.h>
 #include <lscpp/protocol/CompletionItem.h>
 #include <lscpp/protocol/CompletionParams.h>
 #include <lscpp/protocol/DidCloseTextDocumentParams.h>
@@ -39,11 +40,15 @@ struct server : lscpp::experimental::server_with_default_handler {
     return {lscpp::protocol::CompletionItem{"foo"},
             lscpp::protocol::CompletionItem{"bar"}};
   }
-  friend void
-  lscpp_handle_did_open(server &, lscpp::protocol::DidOpenTextDocumentParams) {}
-  friend void
+  friend auto
+  lscpp_handle_did_open(server &, lscpp::protocol::DidOpenTextDocumentParams) {
+    return lscpp::experimental::make_notification_message("opened");
+  }
+  friend auto
   lscpp_handle_did_change(server &,
-                          lscpp::protocol::DidChangeTextDocumentParams) {}
+                          lscpp::protocol::DidChangeTextDocumentParams) {
+    return lscpp::experimental::make_notification_message("changed");
+  }
   friend void
   lscpp_handle_did_close(server &,
                          lscpp::protocol::DidCloseTextDocumentParams) {}

--- a/lscpp/include/lscpp/experimental/adl_lsp_server.h
+++ b/lscpp/include/lscpp/experimental/adl_lsp_server.h
@@ -222,15 +222,42 @@ std::optional<std::string> lscpp_handle_message(lscpp_message_handler &hndlr,
                   get_params<method_kind::TEXT_DOCUMENT_COMPLETION>(params)));
   case method_kind::TEXT_DOCUMENT_DID_OPEN:
     assert(has_text_document_sync<Server>);
-    if constexpr (has_text_document_sync<Server>)
-      lscpp_handle_did_open(
-          server, get_params<method_kind::TEXT_DOCUMENT_DID_OPEN>(params));
-    return {};
+    if constexpr (has_text_document_sync<Server>) {
+      // TODO cleanup dispatching on return type
+      // allows to send notifications from the server to the client in a
+      // synchronous implementation (e.g. PublishDiagnostics)
+      // TODO needs type-checking, currently we blindly forward a json string
+      if constexpr (!std::is_same_v<
+                        decltype(lscpp_handle_did_open(
+                            std::declval<Server>(),
+                            std::declval<
+                                protocol::DidOpenTextDocumentParams>())),
+                        void>) {
+        return lscpp_handle_did_open(
+            server, get_params<method_kind::TEXT_DOCUMENT_DID_OPEN>(params));
+      } else {
+        lscpp_handle_did_open(
+            server, get_params<method_kind::TEXT_DOCUMENT_DID_OPEN>(params));
+      }
+      return {};
+    }
   case method_kind::TEXT_DOCUMENT_DID_CHANGE:
     assert(has_text_document_sync<Server>);
-    if constexpr (has_text_document_sync<Server>)
-      lscpp_handle_did_change(
-          server, get_params<method_kind::TEXT_DOCUMENT_DID_CHANGE>(params));
+    if constexpr (has_text_document_sync<Server>) {
+      // TODO see TEXT_DOCUMENT_DID_OPEN
+      if constexpr (!std::is_same_v<
+                        decltype(lscpp_handle_did_change(
+                            std::declval<Server>(),
+                            std::declval<
+                                protocol::DidChangeTextDocumentParams>())),
+                        void>) {
+        return lscpp_handle_did_change(
+            server, get_params<method_kind::TEXT_DOCUMENT_DID_CHANGE>(params));
+      } else {
+        lscpp_handle_did_change(
+            server, get_params<method_kind::TEXT_DOCUMENT_DID_CHANGE>(params));
+      }
+    }
     return {};
   case method_kind::TEXT_DOCUMENT_DID_CLOSE:
     if constexpr (has_text_document_sync<Server>)


### PR DESCRIPTION
This is a temporary solution for synchronous servers to send notifications to the client, e.g. diagnostics.

<a href="https://gitpod.io/#https://github.com/havogt/cmakels/pull/66"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

